### PR TITLE
Add DLT pipeline for Bronze ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # data-engineering-lab-databricks
-Building scalable data pipelines using Bronze-Silver-Gold architecture, Delta Live Tables, and Unity Catalog.
+
+This repository contains sample data and scripts for building data pipelines on Databricks using the Bronze-Silver-Gold architecture.  
+The CSV files in the root directory represent snapshots of insurance-related tables.
+
+## Bronze ingestion with Delta Live Tables
+The file [`pipelines/bronze_dlt.py`](pipelines/bronze_dlt.py) defines a Delta Live Tables (DLT) pipeline that ingests the raw CSV files from a Databricks volume into Bronze tables.
+By default it reads from `/Volumes/principal_lab_dbx/landing/external_data_volume`. The location can be overridden using the `raw_path` pipeline configuration when the pipeline is created.
+The resulting tables are written to the `DEV` catalog inside the `bronze` schema (for example `DEV.bronze.agents`).
+Each table is loaded using simple `spark.read` operations and is augmented with the source filename for lineage.
+
+### Expected primary keys
+- **Agents** – `agent_id`
+- **Customers** – `customer_id`
+- **Policies** – `policy_id`
+- **Products** – `product_id`
+- **Claims** – `claim_id`
+
+These keys uniquely identify records within their respective tables and can be used for downstream merges or upserts.

--- a/pipelines/bronze_dlt.py
+++ b/pipelines/bronze_dlt.py
@@ -1,0 +1,65 @@
+import dlt
+from pyspark.sql import functions as F
+
+# Default location of the CSV files on Databricks Volumes. The path can be
+# overridden with the `raw_path` pipeline configuration when creating the
+# pipeline.
+RAW_PATH = spark.conf.get(
+    "raw_path",
+    "/Volumes/principal_lab_dbx/landing/external_data_volume",
+)
+
+# Tables are written to the DEV catalog inside the `bronze` schema. Update the
+# catalog or schema by changing these constants if needed.
+CATALOG = "DEV"
+SCHEMA = "bronze"
+
+
+def full_name(table: str) -> str:
+    """Return the fully qualified table name."""
+    return f"{CATALOG}.{SCHEMA}.{table}"
+
+@dlt.table(name=full_name("agents"), comment="Raw agent snapshots")
+def agents_bronze():
+    return (
+        spark.read.format("csv")
+            .option("header", True)
+            .load(f"{RAW_PATH}/agents/*.csv")
+            .withColumn("ingest_file", F.input_file_name())
+    )
+
+@dlt.table(name=full_name("customers"), comment="Raw customer snapshots")
+def customers_bronze():
+    return (
+        spark.read.format("csv")
+            .option("header", True)
+            .load(f"{RAW_PATH}/customers/*.csv")
+            .withColumn("ingest_file", F.input_file_name())
+    )
+
+@dlt.table(name=full_name("policies"), comment="Raw policy snapshots")
+def policies_bronze():
+    return (
+        spark.read.format("csv")
+            .option("header", True)
+            .load(f"{RAW_PATH}/policies/*.csv")
+            .withColumn("ingest_file", F.input_file_name())
+    )
+
+@dlt.table(name=full_name("products"), comment="Reference products table")
+def products_bronze():
+    return (
+        spark.read.format("csv")
+            .option("header", True)
+            .load(f"{RAW_PATH}/products/products.csv")
+            .withColumn("ingest_file", F.input_file_name())
+    )
+
+@dlt.table(name=full_name("claims"), comment="Claims table")
+def claims_bronze():
+    return (
+        spark.read.format("csv")
+            .option("header", True)
+            .load(f"{RAW_PATH}/claims/claims.csv")
+            .withColumn("ingest_file", F.input_file_name())
+    )


### PR DESCRIPTION
## Summary
- add a Python Delta Live Tables script that ingests CSV files from ADLS into Bronze tables
- document pipeline usage and primary keys in the README
- update DLT script to read from `principal_lab_dbx` volume and write to `DEV.bronze`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415da5dfa8832abce168ce642acd4d