### PR TITLE
Add environment configurable DLT pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The CSV files in the root directory represent snapshots of insurance-related tab
 ## Bronze ingestion with Delta Live Tables
 The file [`pipelines/bronze_dlt.py`](pipelines/bronze_dlt.py) defines a Delta Live Tables (DLT) pipeline that ingests the raw CSV files from a Databricks volume into Bronze tables.
 By default it reads from `/Volumes/principal_lab_dbx/landing/external_data_volume`. The location can be overridden using the `raw_path` pipeline configuration when the pipeline is created.
-The resulting tables are written to the `DEV` catalog inside the `bronze` schema (for example `DEV.bronze.agents`).
-Each table is loaded using simple `spark.read` operations and is augmented with the source filename for lineage.
+The target catalog and schema can also be set using the `catalog` and `schema` configurations, making it easy to run the same pipeline against different environments (for example `DEV` vs. `PROD`).
+Each table is loaded using simple `spark.read` operations and is augmented with the source filename, ingestion timestamp and optional snapshot date for lineage.
 
 ### Expected primary keys
 - **Agents** – `agent_id`


### PR DESCRIPTION
## Summary
- make the bronze DLT pipeline configurable via `catalog` and `schema` parameters
- enrich ingested tables with timestamp, source file and optional snapshot date
- document new configuration options

## Testing
- `python -m py_compile pipelines/bronze_dlt.py`

------
https://chatgpt.com/codex/tasks/task_e_6844bb1bf6ec832a9507fc72e3be056f